### PR TITLE
Bumping node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6.10"
+  - "14.15.4"
 before_install:
   - npm i -g npm@6.1.0
 jobs:

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,7 @@ service: qos-fixtures
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs14.x
   profile: serverless
 
 functions:


### PR DESCRIPTION
6.10 no longer supported in AWS lambda.